### PR TITLE
Remove Python file docstrings

### DIFF
--- a/shrinkbot.py
+++ b/shrinkbot.py
@@ -60,7 +60,7 @@ def main():
     len_nocomm = float(len(robot_nocomments))
     print 'w/o comm: %5i' % len_nocomm
         
-    minipy.minify(infile, output=outfile_minipy, rename=True, preserve='Robot,act')
+    minipy.minify(infile, output=outfile_minipy, rename=True, preserve='Robot,act', docstrings=True)
     fid=open(outfile_minipy)
     robot_minify=fid.read()
     fid.close()


### PR DESCRIPTION
Previously, whenever you used this on a robot file, it would keep in unnecessary comments that add extra characters to the end file. By adding docstrings=True, minipy will filter out those comments and other docstrings.

I know you include code for removing comments, but I don't think it removes multi-line ones. Minipy, however, can automatically do that. 

For example, using the previous version on my current Curtis (with comments left in) produces a file with ~1250 characters. Using this updated version on Curtis produces an net result of 1213 characters, significiantly better.
